### PR TITLE
Add in mike versioning drop-down

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
         env:
           GITHUB_TOKEN: ${{ env.REPO_GITHUB_TOKEN }}
       - uses: actions/setup-python@v1
@@ -46,8 +50,12 @@ jobs:
           source venv/bin/activate
           poetry install
           
+          git config user.name sudoblark-bot
+          git config user.email enquires@sudoblark.com
+          
           poetry run mike deploy ${RELEASE_TAG_VERSION} --push
-          poetry run mike set-default ${RELEASE_TAG_VERSION} --push
+          poetry run mike alias ${RELEASE_TAG_VERSION} latest --push
+          poetry run mike set-default latest --push
         env:
           GITHUB_TOKEN: ${{ env.ORG_GITHUB_TOKEN }}
         shell: bash

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 This is the core Python library for Sudoblark, mainly used to power CLI tooling
 to augment CI/CD operations.
 
-The live source of documentation may be said to reside [here](https://sudoblark.github.io/sudoblark.python.core/1.0.0). It
+The live source of documentation may be said to reside [here](https://sudoblark.github.io/sudoblark.python.core/latest). It
 is recommended for developers to at least read the "Developers notes" section
 before attempting to contribute to this repo.
 

--- a/docs/pypi_readme.md
+++ b/docs/pypi_readme.md
@@ -3,7 +3,7 @@
 This is the core Python library for Sudoblark, mainly used to power CLI tooling
 to augment CI/CD operations.
 
-The live source of documentation may be said to reside [here](https://sudoblark.github.io/sudoblark.python.core/1.0.0). It
+The live source of documentation may be said to reside [here](https://sudoblark.github.io/sudoblark.python.core/latest). It
 is recommended for to give that a read, in particular the "Useful Examples" and "Usage", sections
 before interacting with this package.
 


### PR DESCRIPTION
# Description

Resolve minor bugs in release process, and add in an `alias`, to achieve the desired functionality from the previous PR:

- Allow navigate to fixed `latest` URL to access the doc site
- A proper dropdown:

![image](https://github.com/user-attachments/assets/64290200-fc3a-4b51-a1c4-8c58ba19096d)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

See screenshot above, and CI process.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] Code coverage has not been reduced below 95% by my changes
- [x] I have written new unit and integration tests to cover added functionality
- [x] Said unit and integration tests have passed
- [x] Existing tests pass locally with my changes
- [x] My code does not produce any flake8 lint warnings
- [x] My code does not introduce new bandit warnings
